### PR TITLE
Remove bc::stealth_prefix referencing code.

### DIFF
--- a/include/bitcoin/client/obelisk_codec.hpp
+++ b/include/bitcoin/client/obelisk_codec.hpp
@@ -120,9 +120,9 @@ public:
     BCC_API void fetch_stealth(error_handler&& on_error,
         fetch_stealth_handler&& on_reply,
         const stealth_prefix& prefix, size_t from_height=0);
-    BCC_API void fetch_stealth(error_handler&& on_error,
-        fetch_stealth_handler&& on_reply,
-        const bc::stealth_prefix& prefix, size_t from_height=0);
+//    BCC_API void fetch_stealth(error_handler&& on_error,
+//        fetch_stealth_handler&& on_reply,
+//        const bc::stealth_prefix& prefix, size_t from_height=0);
     BCC_API void validate(error_handler&& on_error,
         validate_handler&& on_reply,
         const transaction_type& tx);
@@ -138,9 +138,9 @@ public:
     BCC_API void subscribe(error_handler&& on_error,
         empty_handler&& on_reply,
         const bc::payment_address& address);
-    BCC_API void subscribe(error_handler&& on_error,
-        empty_handler&& on_reply,
-        const address_prefix& prefix);
+//    BCC_API void subscribe(error_handler&& on_error,
+//        empty_handler&& on_reply,
+//        const address_prefix& prefix);
 
     BCC_API uint64_t outstanding_call_count() const;
 

--- a/include/bitcoin/client/obelisk_v1_types.hpp
+++ b/include/bitcoin/client/obelisk_v1_types.hpp
@@ -33,7 +33,7 @@ struct BCC_API stealth_prefix
     stealth_bitfield bitfield;
 };
 
-typedef bc::stealth_prefix address_prefix;
+//typedef bc::stealth_prefix address_prefix;
 
 struct BCC_API history_row
 {

--- a/src/obelisk_codec.cpp
+++ b/src/obelisk_codec.cpp
@@ -252,32 +252,32 @@ BCC_API void obelisk_codec::fetch_stealth(error_handler&& on_error,
         std::bind(decode_fetch_stealth, _1, std::move(on_reply)));
 }
 
-BCC_API void obelisk_codec::fetch_stealth(error_handler&& on_error,
-    fetch_stealth_handler&& on_reply,
-    const bc::stealth_prefix& prefix, size_t from_height)
-{
-    // BUGBUG: assertion is not good enough here.
-    BITCOIN_ASSERT(prefix.size() <= 255);
-
-    data_chunk data(1 + prefix.num_blocks() + 4);
-    auto serial = make_serializer(data.begin());
-    // number_bits
-
-    // BUGBUG: the API should be limited to uint8_t.
-    serial.write_byte(static_cast<uint8_t>(prefix.size()));
-
-    // Serialize bitfield to raw bytes and serialize
-    data_chunk bitfield(prefix.num_blocks());
-    boost::to_block_range(prefix, bitfield.begin());
-    serial.write_data(bitfield);
-
-    // BUGBUG: the API should be limited to uint32_t.
-    serial.write_4_bytes(static_cast<uint32_t>(from_height));
-    BITCOIN_ASSERT(serial.iterator() == data.end());
-
-    send_request("blockchain.fetch_stealth", data, std::move(on_error),
-        std::bind(decode_fetch_stealth, _1, std::move(on_reply)));
-}
+//BCC_API void obelisk_codec::fetch_stealth(error_handler&& on_error,
+//    fetch_stealth_handler&& on_reply,
+//    const bc::stealth_prefix& prefix, size_t from_height)
+//{
+//    // BUGBUG: assertion is not good enough here.
+//    BITCOIN_ASSERT(prefix.size() <= 255);
+//
+//    data_chunk data(1 + prefix.num_blocks() + 4);
+//    auto serial = make_serializer(data.begin());
+//    // number_bits
+//
+//    // BUGBUG: the API should be limited to uint8_t.
+//    serial.write_byte(static_cast<uint8_t>(prefix.size()));
+//
+//    // Serialize bitfield to raw bytes and serialize
+//    data_chunk bitfield(prefix.num_blocks());
+//    boost::to_block_range(prefix, bitfield.begin());
+//    serial.write_data(bitfield);
+//
+//    // BUGBUG: the API should be limited to uint32_t.
+//    serial.write_4_bytes(static_cast<uint32_t>(from_height));
+//    BITCOIN_ASSERT(serial.iterator() == data.end());
+//
+//    send_request("blockchain.fetch_stealth", data, std::move(on_error),
+//        std::bind(decode_fetch_stealth, _1, std::move(on_reply)));
+//}
 
 BCC_API void obelisk_codec::validate(error_handler&& on_error,
     validate_handler&& on_reply,
@@ -351,20 +351,20 @@ BCC_API void obelisk_codec::subscribe(error_handler&& on_error,
         std::bind(decode_empty, _1, std::move(on_reply)));
 }
 
-BCC_API void obelisk_codec::subscribe(error_handler&& on_error,
-    empty_handler&& on_reply,
-    const address_prefix& prefix)
-{
-    // BUGBUG: assertion is not good enough here.
-    BITCOIN_ASSERT(prefix.size() <= 255);
-
-    data_chunk data(1 + prefix.num_blocks());
-    data[0] = static_cast<uint8_t>(prefix.size());
-    boost::to_block_range(prefix, data.begin() + 1);
-
-    send_request("address.subscribe", data, std::move(on_error),
-        std::bind(decode_empty, _1, std::move(on_reply)));
-}
+//BCC_API void obelisk_codec::subscribe(error_handler&& on_error,
+//    empty_handler&& on_reply,
+//    const address_prefix& prefix)
+//{
+//    // BUGBUG: assertion is not good enough here.
+//    BITCOIN_ASSERT(prefix.size() <= 255);
+//
+//    data_chunk data(1 + prefix.num_blocks());
+//    data[0] = static_cast<uint8_t>(prefix.size());
+//    boost::to_block_range(prefix, data.begin() + 1);
+//
+//    send_request("address.subscribe", data, std::move(on_error),
+//        std::bind(decode_empty, _1, std::move(on_reply)));
+//}
 
 void obelisk_codec::decode_empty(data_deserial& payload,
     empty_handler& handler)


### PR DESCRIPTION
This code should not have been referenced, and is removed as libbitcoin stealth_prefix has been/is being refactored and introduced breaks.
