### PR TITLE
Do not silently drop unhandled obelisk messages

### DIFF
--- a/src/obelisk/obelisk_router.cpp
+++ b/src/obelisk/obelisk_router.cpp
@@ -37,6 +37,11 @@ BCC_API obelisk_router::obelisk_router(std::shared_ptr<message_stream> out)
 
 obelisk_router::~obelisk_router()
 {
+    for (const auto &request: pending_requests_)
+    {
+        const auto ec = std::make_error_code(std::errc::operation_canceled);
+        request.second.on_error(ec);
+    }
 }
 
 BCC_API void obelisk_router::set_on_update(update_handler on_update)


### PR DESCRIPTION
If the obelisk connection is shut down,
fire the error callback on any pending requests.
This gives the client a chance to clean up any resources
that may be waiting on message completion.

This is a rebase from version2, so please wait on the CI server before merging to be sure it builds.