### PR TITLE
Fixes validate-tx errors on valid transactions

### DIFF
--- a/src/obelisk/obelisk_codec.cpp
+++ b/src/obelisk/obelisk_codec.cpp
@@ -439,7 +439,7 @@ bool obelisk_codec::decode_validate(reader& payload,
     auto success = true;
     index_list unconfirmed;
 
-    while (success && payload.is_exhausted())
+    while (success && !payload.is_exhausted())
     {
         unconfirmed.push_back(payload.read_4_bytes_little_endian());
         success = payload;


### PR DESCRIPTION
Simple logic inversion bug causing validate transaction to fail even when it succeeds (based on erroneously exhausted stream state)