### PR TITLE
Remove libsodium dependency (requires zmq 4.2).

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,8 +32,8 @@ doc_DATA = \
 # src/libbitcoin-client.la => ${libdir}
 #------------------------------------------------------------------------------
 lib_LTLIBRARIES = src/libbitcoin-client.la
-src_libbitcoin_client_la_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${sodium_CPPFLAGS} ${czmq___CPPFLAGS}
-src_libbitcoin_client_la_LIBADD = ${bitcoin_LIBS} ${sodium_LIBS} ${czmq___LIBS}
+src_libbitcoin_client_la_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${czmq___CPPFLAGS}
+src_libbitcoin_client_la_LIBADD = ${bitcoin_LIBS} ${czmq___LIBS}
 src_libbitcoin_client_la_SOURCES = \
     src/dealer.cpp \
     src/proxy.cpp \
@@ -46,8 +46,8 @@ if WITH_TESTS
 TESTS = libbitcoin_client_test_runner.sh
 
 check_PROGRAMS = test/libbitcoin_client_test
-test_libbitcoin_client_test_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${sodium_CPPFLAGS} ${czmq___CPPFLAGS}
-test_libbitcoin_client_test_LDADD = src/libbitcoin-client.la ${boost_unit_test_framework_LIBS} ${bitcoin_LIBS} ${sodium_LIBS} ${czmq___LIBS}
+test_libbitcoin_client_test_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${czmq___CPPFLAGS}
+test_libbitcoin_client_test_LDADD = src/libbitcoin-client.la ${boost_unit_test_framework_LIBS} ${bitcoin_LIBS} ${czmq___LIBS}
 test_libbitcoin_client_test_SOURCES = \
     test/main.cpp \
     test/proxy.cpp
@@ -59,8 +59,8 @@ endif WITH_TESTS
 if WITH_EXAMPLES
 
 noinst_PROGRAMS = examples/console/console
-examples_console_console_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${sodium_CPPFLAGS} ${czmq___CPPFLAGS}
-examples_console_console_LDADD = src/libbitcoin-client.la ${bitcoin_LIBS} ${sodium_LIBS} ${czmq___LIBS}
+examples_console_console_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${czmq___CPPFLAGS}
+examples_console_console_LDADD = src/libbitcoin-client.la ${bitcoin_LIBS} ${czmq___LIBS}
 examples_console_console_SOURCES = \
     examples/console/cli.cpp \
     examples/console/cli.hpp \
@@ -77,8 +77,8 @@ endif WITH_EXAMPLES
 if WITH_EXAMPLES
 
 noinst_PROGRAMS += examples/get_height/get_height
-examples_get_height_get_height_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${sodium_CPPFLAGS} ${czmq___CPPFLAGS}
-examples_get_height_get_height_LDADD = src/libbitcoin-client.la ${bitcoin_LIBS} ${sodium_LIBS} ${czmq___LIBS}
+examples_get_height_get_height_CPPFLAGS = -I${srcdir}/include ${bitcoin_CPPFLAGS} ${czmq___CPPFLAGS}
+examples_get_height_get_height_LDADD = src/libbitcoin-client.la ${bitcoin_LIBS} ${czmq___LIBS}
 examples_get_height_get_height_SOURCES = \
     examples/get_height/main.cpp
 

--- a/configure.ac
+++ b/configure.ac
@@ -133,15 +133,6 @@ AS_CASE([${with_tests}], [yes],
      AC_MSG_NOTICE([boost_unit_test_framework_LIBS : ${boost_unit_test_framework_LIBS}])],
     [AC_SUBST([boost_unit_test_framework_LIBS], [])])
 
-# Require sodium of at least version 1.0.0 and output ${sodium_CPPFLAGS/LIBS/PKG}.
-#------------------------------------------------------------------------------
-# The chained zmq dependency doesn't set a minimum version for sodium.
-PKG_CHECK_MODULES([sodium], [libsodium >= 1.0.0])
-AC_SUBST([sodium_PKG], ['libsodium >= 1.0.0'])
-AC_SUBST([sodium_CPPFLAGS], [${sodium_CFLAGS}])
-AC_MSG_NOTICE([sodium_CPPFLAGS : ${sodium_CPPFLAGS}])
-AC_MSG_NOTICE([sodium_LIBS : ${sodium_LIBS}])
-
 # Require czmq++ of at least version 1.2.0 and output ${czmq___CPPFLAGS/LIBS/PKG}.
 #------------------------------------------------------------------------------
 PKG_CHECK_MODULES([czmq__], [libczmq++ >= 1.2.0])

--- a/install.sh
+++ b/install.sh
@@ -195,16 +195,6 @@ BOOST_OPTIONS=(
 "--with-thread" \
 "--with-test")
 
-# Define sodium options.
-#------------------------------------------------------------------------------
-SODIUM_OPTIONS=(
-"${with_pkgconfigdir}")
-
-# Define zmq options.
-#------------------------------------------------------------------------------
-ZMQ_OPTIONS=(
-"--with-libsodium")
-
 # Define czmq options.
 #------------------------------------------------------------------------------
 CZMQ_OPTIONS=(
@@ -684,7 +674,6 @@ build_from_travis()
 build_all()
 {
     build_from_tarball_boost $BOOST_URL $BOOST_ARCHIVE bzip2 . $PARALLEL "$BUILD_BOOST" "${BOOST_OPTIONS[@]}"
-    build_from_github jedisct1 libsodium master $PARALLEL ${SODIUM_OPTIONS[@]} "$@"
     build_from_github zeromq libzmq master $PARALLEL ${ZMQ_OPTIONS[@]} "$@"
     build_from_github zeromq czmq master $PARALLEL ${CZMQ_OPTIONS[@]} "$@"
     build_from_github zeromq czmqpp master $PARALLEL ${CZMQPP_OPTIONS[@]} "$@"

--- a/libbitcoin-client.pc.in
+++ b/libbitcoin-client.pc.in
@@ -25,7 +25,7 @@ Version: @PACKAGE_VERSION@
 #==============================================================================
 # Dependencies that publish package configuration.
 #------------------------------------------------------------------------------
-Requires: libbitcoin >= 3.0.0 libsodium >= 1.0.0 libczmq++ >= 1.2.0
+Requires: libbitcoin >= 3.0.0 libczmq++ >= 1.2.0
 
 # Include directory and any other required compiler flags.
 #------------------------------------------------------------------------------


### PR DESCRIPTION
ZeroMQ 4.2+ embeds tweetnacl and enables curve by default.