### PR TITLE
Change missing output history default to max uint64 from max uint32.

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -442,7 +442,7 @@ history::list proxy::expand(history_compact::list& compact)
             history row;
             row.output = { null_hash, max_uint32 };
             row.output_height = max_uint64;
-            row.value = max_uint32;
+            row.value = max_uint64;
             row.spend = spend.point;
             row.spend_height = spend.height;
             result.emplace_back(row);


### PR DESCRIPTION
https://github.com/libbitcoin/libbitcoin-client/issues/141