### PR TITLE
initializing list require corresponding sort.

### DIFF
--- a/examples/console/client.hpp
+++ b/examples/console/client.hpp
@@ -96,8 +96,8 @@ private:
      */
     bool done_;
     bool pending_request_;
-    read_line terminal_;
     bc::protocol::zmq::context context_;
+    read_line terminal_;
     std::shared_ptr<connection> connection_;
 };
 


### PR DESCRIPTION
/usr/include/boost/thread/pthread/shared_mutex.hpp:58: void boost::shared_mutex::state_data::assert_lock_shared() const: Assertion `! exclusive' failed.
Aborted (core dumped)

-----------------
`client::client()
  : done_(false),
    pending_request_(false),
    **terminal_(context_)**
{
}`