### PR TITLE
Fixes 2 client issues that manifest in bx usage.

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -143,12 +143,10 @@ void proxy::blockchain_fetch_history(error_handler on_error,
     history_handler on_reply, const payment_address& address,
     uint32_t from_height)
 {
-    auto hash = address.hash();
-    std::reverse(hash.begin(), hash.end());
     const auto data = build_chunk(
     {
         to_array(address.version()),
-        hash,
+        address.hash(),
         to_little_endian<uint32_t>(from_height)
     });
 
@@ -224,7 +222,7 @@ void proxy::address_fetch_unspent_outputs(error_handler on_error,
         on_reply(selected_utxos);
     };
 
-    send_request("address.fetch_history2", data, on_error,
+    send_request("blockchain.fetch_history", data, on_error,
         std::bind(decode_history,
             _1, std::move(parse_history)));
 }

--- a/test/proxy.cpp
+++ b/test/proxy.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(proxy__fetch_history__test)
     HANDLE_ROUTING_FRAMES(capture.out);
     BOOST_REQUIRE_EQUAL(capture.out.size(), 3u);
     BOOST_REQUIRE_EQUAL(to_string(capture.out[0]), "blockchain.fetch_history");
-    BOOST_REQUIRE_EQUAL(encode_base16(capture.out[2]), "0035a131e99f240a2314bb0ddb3d81d05663eb5bf878563412");
+    BOOST_REQUIRE_EQUAL(encode_base16(capture.out[2]), "00f85beb6356d0813ddb0dbb14230a249fe931a13578563412");
 }
 
 BOOST_AUTO_TEST_CASE(proxy__fetch_transaction__test)


### PR DESCRIPTION
Removes hash reversal on history fetch (no longer needed).
Resolves libbitcoin/libbitcoin-explorer#342

Updates fetch_unspent_outputs from address.fetch_history2 (now
obsolete) to blockchain.fetch_history api