### PR TITLE
Revert "propagate new bc::settings class"

### DIFF
--- a/examples/console/connection.cpp
+++ b/examples/console/connection.cpp
@@ -22,7 +22,6 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
-#include <bitcoin/bitcoin.hpp>
 #include <bitcoin/client.hpp>
 
 using namespace bc;
@@ -46,7 +45,7 @@ static void on_update(const code&, uint16_t sequence, size_t,
 
 connection::connection(zmq::socket& socket, uint32_t timeout_ms)
   : stream(socket),
-    proxy(stream, on_unknown, timeout_ms, 0, bc::settings())
+    proxy(stream, on_unknown, timeout_ms, 0)
 {
     proxy.set_on_update(on_update);
 }

--- a/examples/get_height/main.cpp
+++ b/examples/get_height/main.cpp
@@ -18,7 +18,6 @@
  */
 #include <iostream>
 #include <memory>
-#include <bitcoin/bitcoin.hpp>
 #include <bitcoin/client.hpp>
 
 using namespace bc;
@@ -64,7 +63,7 @@ int main(int argc, char* argv[])
     socket_stream stream(socket);
 
     // Wait 2 seconds for the connection, with no failure retries.
-    proxy proxy(stream, unknown_handler, 2000, 0, bc::settings());
+    proxy proxy(stream, unknown_handler, 2000, 0);
 
     // Make the request.
     proxy.blockchain_fetch_last_height(error_handler, completion_handler);

--- a/include/bitcoin/client/obelisk_client.hpp
+++ b/include/bitcoin/client/obelisk_client.hpp
@@ -20,7 +20,6 @@
 #define LIBBITCOIN_CLIENT_OBELISK_CLIENT_HPP
 
 #include <cstdint>
-#include <bitcoin/bitcoin.hpp>
 #include <bitcoin/protocol.hpp>
 #include <bitcoin/client/define.hpp>
 #include <bitcoin/client/proxy.hpp>
@@ -52,12 +51,10 @@ public:
         transaction_update_handler;
 
     /// Construct an instance of the client using timeout/retries from channel.
-    obelisk_client(const connection_type& channel,
-        const bc::settings& bitcoin_settings);
+    obelisk_client(const connection_type& channel);
 
     /// Construct an instance of the client using the specified parameters.
-    obelisk_client(uint16_t timeout_seconds, uint8_t retries,
-        const bc::settings& bitcoin_settings);
+    obelisk_client(uint16_t timeout_seconds, uint8_t retries);
 
     /// Connect to the specified endpoint using the provided keys.
     virtual bool connect(const config::endpoint& address,
@@ -92,7 +89,6 @@ private:
     transaction_update_handler on_transaction_update_;
     socket_stream stream_;
     const uint8_t retries_;
-    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace client

--- a/include/bitcoin/client/proxy.hpp
+++ b/include/bitcoin/client/proxy.hpp
@@ -40,8 +40,7 @@ public:
     /// Resend is unrelated to connections.
     /// Timeout is capped at max_int32 (vs. max_uint32).
     proxy(stream& out, unknown_handler on_unknown_command,
-        uint32_t timeout_milliseconds, uint8_t resends,
-        const bc::settings& bitcoin_settings);
+        uint32_t timeout_milliseconds, uint8_t resends);
 
     // Fetch handler types.
     //-------------------------------------------------------------------------
@@ -124,7 +123,7 @@ private:
         transaction_handler& handler);
     static bool decode_height(reader& payload, height_handler& handler);
     static bool decode_block_header(reader& payload,
-        const bc::settings& bitcoin_settings, block_header_handler& handler);
+        block_header_handler& handler);
     static bool decode_transaction_index(reader& payload,
         transaction_index_handler& handler);
     static bool decode_stealth(reader& payload, stealth_handler& handler);
@@ -134,8 +133,6 @@ private:
     //-------------------------------------------------------------------------
     static stealth::list expand(chain::stealth_record::list& record);
     static history::list expand(chain::payment_record::list& record);
-
-    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace client

--- a/src/obelisk_client.cpp
+++ b/src/obelisk_client.cpp
@@ -50,22 +50,18 @@ static const auto on_unknown = [](const std::string&){};
 
 // Retries is overloaded as configuration for resends as well.
 // Timeout is capped at ~ 25 days by signed/millsecond conversions.
-obelisk_client::obelisk_client(uint16_t timeout_seconds, uint8_t retries,
-    const bc::settings& bitcoin_settings)
+obelisk_client::obelisk_client(uint16_t timeout_seconds, uint8_t retries)
   : socket_(context_, zmq::socket::role::dealer),
     block_socket_(context_, zmq::socket::role::subscriber),
     transaction_socket_(context_, zmq::socket::role::subscriber),
     stream_(socket_),
     retries_(retries),
-    bitcoin_settings_(bitcoin_settings),
-    proxy(stream_, on_unknown, to_milliseconds(timeout_seconds), retries,
-        bitcoin_settings)
+    proxy(stream_, on_unknown, to_milliseconds(timeout_seconds), retries)
 {
 }
 
-obelisk_client::obelisk_client(const connection_type& channel,
-    const bc::settings& bitcoin_settings)
-  : obelisk_client(channel.timeout_seconds, channel.retries, bitcoin_settings)
+obelisk_client::obelisk_client(const connection_type& channel)
+  : obelisk_client(channel.timeout_seconds, channel.retries)
 {
 }
 
@@ -190,7 +186,7 @@ void obelisk_client::monitor(uint32_t timeout_seconds)
             message.dequeue(height);
             message.dequeue(data);
 
-            bc::chain::block block(bitcoin_settings_);
+            bc::chain::block block;
             block.from_data(data, true);
 
             on_block_update_(block);

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -38,10 +38,8 @@ using namespace bc::chain;
 using namespace bc::wallet;
 
 proxy::proxy(stream& out, unknown_handler on_unknown_command,
-    uint32_t timeout_milliseconds, uint8_t resends,
-    const bc::settings& bitcoin_settings)
-  : dealer(out, on_unknown_command, timeout_milliseconds, resends),
-    bitcoin_settings_(bitcoin_settings)
+    uint32_t timeout_milliseconds, uint8_t resends)
+  : dealer(out, on_unknown_command, timeout_milliseconds, resends)
 {
 }
 
@@ -139,7 +137,7 @@ void proxy::blockchain_fetch_block_header(error_handler on_error,
 
     send_request("blockchain.fetch_block_header", data, on_error,
         std::bind(decode_block_header,
-            _1, std::ref(bitcoin_settings_), on_reply));
+            _1, on_reply));
 }
 
 void proxy::blockchain_fetch_block_header(error_handler on_error,
@@ -149,7 +147,7 @@ void proxy::blockchain_fetch_block_header(error_handler on_error,
 
     send_request("blockchain.fetch_block_header", data, on_error,
         std::bind(decode_block_header,
-            _1, std::ref(bitcoin_settings_), on_reply));
+            _1, on_reply));
 }
 
 void proxy::blockchain_fetch_transaction_index(error_handler on_error,
@@ -314,10 +312,9 @@ bool proxy::decode_height(reader& payload, height_handler& handler)
     return true;
 }
 
-bool proxy::decode_block_header(reader& payload,
-    const bc::settings& bitcoin_settings, block_header_handler& handler)
+bool proxy::decode_block_header(reader& payload, block_header_handler& handler)
 {
-    chain::header header(bitcoin_settings);
+    chain::header header;
     if (!header.from_data(payload) || !payload.is_exhausted())
         return false;
 

--- a/test/proxy.cpp
+++ b/test/proxy.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test_suite.hpp>
-#include <bitcoin/bitcoin.hpp>
 #include <bitcoin/client.hpp>
 
 using namespace bc;
@@ -82,7 +81,7 @@ static const char address_satoshi[] = "1PeChFbhxDD9NLbU21DfD55aQBC4ZTR3tE";
     static const auto on_error = [](const code&) {}; \
     static const auto on_unknown = [](const std::string&) {}; \
     stream_fixture capture; \
-    proxy proxy(capture, on_unknown, timeout_ms, retries, bc::settings())
+    proxy proxy(capture, on_unknown, timeout_ms, retries)
 
 // Allow REQ or unadressed DEALER client.
 #define HANDLE_ROUTING_FRAMES(stack) \


### PR DESCRIPTION
This reverts commit 7db30f28067d2da6d80596d8d0fa4acc6069e781.

Reason: https://github.com/libbitcoin/libbitcoin/pull/1013