### PR TITLE
No longer suppress immediate send_request failures by the client

### DIFF
--- a/include/bitcoin/client/obelisk_client.hpp
+++ b/include/bitcoin/client/obelisk_client.hpp
@@ -177,6 +177,8 @@ public:
 private:
     // Attach handlers for all supported client-server operations.
     void attach_handlers();
+    void handle_immediate(const std::string& command, uint32_t id,
+        const code& ec);
 
     // Determines if any requests have not been handled.
     bool requests_outstanding();


### PR DESCRIPTION
No longer suppress immediate send_request failures by the client (instead of waiting until the timeout to detect)

Resolves #174