### PR TITLE
Split up client queries that are waited on vs monitored, add unsubscribe

### DIFF
--- a/include/bitcoin/client/obelisk_client.hpp
+++ b/include/bitcoin/client/obelisk_client.hpp
@@ -45,8 +45,7 @@ struct BCC_API connection_settings
 class BCC_API obelisk_client
 {
 public:
-    static const uint32_t null_subscription =
-        std::numeric_limits<uint32_t>::max();
+    static const auto null_subscription = bc::max_uint32;
 
     typedef std::function<void(const std::string&, uint32_t,
         const system::data_chunk&)> command_handler;
@@ -297,7 +296,7 @@ private:
     version_handler_map version_handlers_;
 
     // Protects subscription_handlers_
-    system::shared_mutex subscription_lock_;
+    system::upgrade_mutex subscription_lock_;
 };
 
 } // namespace client

--- a/include/bitcoin/client/obelisk_client.hpp
+++ b/include/bitcoin/client/obelisk_client.hpp
@@ -45,6 +45,9 @@ struct BCC_API connection_settings
 class BCC_API obelisk_client
 {
 public:
+    static const uint32_t null_subscription =
+        std::numeric_limits<uint32_t>::max();
+
     typedef std::function<void(const std::string&, uint32_t,
         const system::data_chunk&)> command_handler;
     typedef std::unordered_map<std::string, command_handler> command_map;
@@ -85,7 +88,10 @@ public:
     typedef std::unordered_map<uint32_t, transaction_handler> transaction_handler_map;
     typedef std::unordered_map<uint32_t, history_handler> history_handler_map;
     typedef std::unordered_map<uint32_t, stealth_handler> stealth_handler_map;
-    typedef std::unordered_map<uint32_t, update_handler> update_handler_map;
+    typedef std::unordered_map<uint32_t, std::pair<update_handler,
+        system::data_chunk>> subscription_handler_map;
+    typedef std::unordered_map<uint32_t, std::pair<result_handler,
+        uint32_t>> unsubscription_handler_map;
     typedef std::unordered_map<uint32_t, hash_list_handler> hash_list_handler_map;
     typedef std::unordered_map<uint32_t, version_handler> version_handler_map;
 
@@ -190,13 +196,16 @@ public:
     // Subscribers.
     //-------------------------------------------------------------------------
 
-    void subscribe_address(update_handler handler,
+    // Subscribe to a payment address.  Return value can be used to unsubscribe.
+    uint32_t subscribe_address(update_handler handler,
         const system::wallet::payment_address& address);
 
-    void subscribe_address(update_handler handler,
+    // Subscribe to an address hash.  Return value can be used to unsubscribe.
+    uint32_t subscribe_address(update_handler handler,
         const system::short_hash& address_hash);
 
-    void subscribe_stealth(update_handler handler,
+    // Subscribe to a stealth prefix.  Return value can be used to unsubscribe.
+    uint32_t subscribe_stealth(update_handler handler,
         const system::binary& stealth_prefix);
 
     bool subscribe_block(const system::config::endpoint& address,
@@ -205,26 +214,54 @@ public:
     bool subscribe_transaction(const system::config::endpoint& address,
         transaction_update_handler on_update);
 
+    // Unsubscribers.
+    //-------------------------------------------------------------------------
+
+    bool unsubscribe_address(result_handler handler, uint32_t subscription);
+
+    bool unsubscribe_stealth(result_handler handler, uint32_t subscription);
+
 private:
     // Attach handlers for all supported client-server operations.
     void attach_handlers();
+
+    // Used to handle a request immediately, on early detection of error.
     void handle_immediate(const std::string& command, uint32_t id,
         const system::code& ec);
 
     // Determines if any requests have not been handled.
     bool requests_outstanding();
 
+    // Determines if any notification requests have not been handled.
+    bool subscribe_requests_outstanding();
+
     // Calls all remaining/expired handlers with the specified error.
     void clear_outstanding_requests(const system::code& ec);
 
+    // Calls all remaining/expired notification handlers with the specified
+    // error.
+    void clear_outstanding_subscribe_requests(const system::code& ec);
+
     // Sends an outgoing request via the internal router.
     bool send_request(const std::string& command, uint32_t id,
-        const system::data_chunk& payload);
+        const system::data_chunk& payload, bool subscription=false);
+
+    // Forward incoming client router requests to the server.
+    void forward_message(protocol::zmq::socket& source,
+        protocol::zmq::socket& sink);
+
+    // Process server responses.
+    void process_response(protocol::zmq::socket& socket);
+
+    // After notifying the server of unsubscribe, this terminates any client
+    // side monitoring state for the subscription.
+    bool terminate_unsubscriber(uint32_t subscription);
 
     protocol::zmq::context context_;
 
     // Sockets that connect to external libbitcoin services.
     protocol::zmq::socket socket_;
+    protocol::zmq::socket subscribe_socket_;
     protocol::zmq::socket block_socket_;
     protocol::zmq::socket transaction_socket_;
 
@@ -233,11 +270,17 @@ private:
     protocol::zmq::socket dealer_;
     protocol::zmq::socket router_;
 
+    // Internal socket pair for client subscription request forwarding to router
+    // (that then forwards to server).
+    protocol::zmq::socket subscribe_dealer_;
+    protocol::zmq::socket subscribe_router_;
+
     block_update_handler on_block_update_;
     transaction_update_handler on_transaction_update_;
     int32_t retries_;
     bool secure_;
     system::config::endpoint worker_;
+    system::config::endpoint subscribe_worker_;
     uint32_t last_request_index_;
     command_map command_handlers_;
     result_handler_map result_handlers_;
@@ -248,9 +291,13 @@ private:
     transaction_handler_map transaction_handlers_;
     history_handler_map history_handlers_;
     stealth_handler_map stealth_handlers_;
-    update_handler_map update_handlers_;
+    subscription_handler_map subscription_handlers_;
+    unsubscription_handler_map unsubscription_handlers_;
     hash_list_handler_map hash_list_handlers_;
     version_handler_map version_handlers_;
+
+    // Protects subscription_handlers_
+    system::shared_mutex subscription_lock_;
 };
 
 } // namespace client

--- a/src/obelisk_client.cpp
+++ b/src/obelisk_client.cpp
@@ -38,16 +38,25 @@ namespace client {
 static const config::endpoint public_worker("inproc://public_client");
 static const config::endpoint secure_worker("inproc://secure_client");
 
+static const config::endpoint public_subscribe_worker(
+    "inproc://public_subscribe_client");
+static const config::endpoint secure_subscribe_worker(
+    "inproc://secure_subscribe_client");
+
 obelisk_client::obelisk_client(int32_t retries)
   : socket_(context_, zmq::socket::role::dealer),
+    subscribe_socket_(context_, zmq::socket::role::dealer),
     block_socket_(context_, zmq::socket::role::subscriber),
     transaction_socket_(context_, zmq::socket::role::subscriber),
     dealer_(context_, zmq::socket::role::dealer),
     router_(context_, zmq::socket::role::router),
+    subscribe_dealer_(context_, zmq::socket::role::dealer),
+    subscribe_router_(context_, zmq::socket::role::router),
     retries_(retries),
     last_request_index_(0),
     secure_(false),
-    worker_(public_worker)
+    worker_(public_worker),
+    subscribe_worker_(public_subscribe_worker)
 {
     attach_handlers();
 }
@@ -56,7 +65,10 @@ obelisk_client::~obelisk_client()
 {
     dealer_.stop();
     router_.stop();
+    subscribe_dealer_.stop();
+    subscribe_router_.stop();
     socket_.stop();
+    subscribe_socket_.stop();
     block_socket_.stop();
     transaction_socket_.stop();
 }
@@ -73,21 +85,25 @@ bool obelisk_client::connect(const endpoint& address,
     const sodium& client_private_key)
 {
     // Ignore the setting if socks.port is zero (invalid).
-    if (socks_proxy && !socket_.set_socks_proxy(socks_proxy))
+    if (socks_proxy && (!socket_.set_socks_proxy(socks_proxy) ||
+        !subscribe_socket_.set_socks_proxy(socks_proxy)))
         return false;
 
     // Only apply the client (and server) key if server key is configured.
     if (server_public_key)
     {
-        if (!socket_.set_curve_client(server_public_key))
+        if (!socket_.set_curve_client(server_public_key) ||
+            !subscribe_socket_.set_curve_client(server_public_key))
             return false;
 
         // Generates arbitrary client keys if private key is not configured.
-        if (!socket_.set_certificate({ client_private_key }))
+        if (!socket_.set_certificate({ client_private_key }) ||
+            !subscribe_socket_.set_certificate({ client_private_key }))
             return false;
 
         secure_ = true;
         worker_ = secure_worker;
+        subscribe_worker_ = secure_subscribe_worker;
     }
 
     return connect(address);
@@ -97,28 +113,74 @@ bool obelisk_client::connect(const endpoint& address)
 {
     const auto host_address = address.to_string();
 
-    for (auto attempt = 0; attempt < 1 + retries_; ++attempt)
+    auto connect_socket = [this, &host_address](zmq::socket& socket,
+        zmq::socket& dealer, zmq::socket& router, config::endpoint& worker)
     {
-        if (socket_.connect(host_address) == error::success)
+        if (socket.connect(host_address) == error::success)
         {
-            // Bind internal router to inproc worker
-            auto ec = router_.bind(worker_);
+            // Bind internal router(s) to inproc worker
+            auto ec = router.bind(worker);
             if (ec)
                 return false;
 
-            // Connect internal socket to worker router
-            ec = dealer_.connect(worker_);
+            // Connect internal socket(s) to worker router
+            ec = dealer.connect(worker);
             if (ec)
                 return false;
 
             return true;
         }
 
+        return false;
+    };
+
+    for (auto attempt = 0; attempt < 1 + retries_; ++attempt)
+    {
+        // subscribe_socket connection could be deferred/unused unless a
+        // subscribe call was made.
+        if (connect_socket(socket_, dealer_, router_, worker_) &&
+            connect_socket(subscribe_socket_, subscribe_dealer_,
+                subscribe_router_, subscribe_worker_))
+            return true;
+
         // Arbitrary delay between connection attempts.
         sleep_for(asio::milliseconds((attempt + 1) * 100));
     }
 
     return false;
+}
+
+void obelisk_client::forward_message(zmq::socket& source, zmq::socket& sink)
+{
+    // Forward incoming client router requests to the server.
+    zmq::message packet;
+    source.receive(packet);
+    // Strip the router delimiter before forwarding.
+    packet.dequeue();
+    sink.send(packet);
+}
+
+void obelisk_client::process_response(zmq::socket& socket)
+{
+    // Process server responses.
+    zmq::message message;
+    socket.receive(message);
+
+    // Strip the delimiter if the server includes it.
+    if (message.size() == 4)
+        message.dequeue();
+
+    uint32_t id = 0;
+    std::string command;
+    data_chunk payload;
+
+    message.dequeue(command);
+    message.dequeue(id);
+    message.dequeue(payload);
+
+    const auto handler = command_handlers_.find(command);
+    if (handler != command_handlers_.end())
+        handler->second(command, id, payload);
 }
 
 // Used by query commands and fires handlers as needed.
@@ -138,36 +200,11 @@ void obelisk_client::wait(uint32_t timeout_milliseconds)
 
         // Forward incoming client router requests to the server.
         if (identifiers.contains(router_.id()))
-        {
-            zmq::message packet;
-            router_.receive(packet);
-            // Strip the router delimiter before forwarding.
-            packet.dequeue();
-            socket_.send(packet);
-        }
+            forward_message(router_, socket_);
 
         // Process server responses.
         if (identifiers.contains(socket_.id()))
-        {
-            zmq::message message;
-            socket_.receive(message);
-
-            // Strip the delimiter if the server includes it.
-            if (message.size() == 4)
-                message.dequeue();
-
-            uint32_t id = 0;
-            std::string command;
-            data_chunk payload;
-
-            message.dequeue(command);
-            message.dequeue(id);
-            message.dequeue(payload);
-
-            const auto handler = command_handlers_.find(command);
-            if (handler != command_handlers_.end())
-                handler->second(command, id, payload);
-        }
+            process_response(socket_);
     }
 
     // Timeout or otherwise notify any remaining requests.
@@ -202,12 +239,14 @@ bool obelisk_client::subscribe_transaction(
     return false;
 }
 
-// Used by subscribe-* commands, fires registered update handlers.
+// Used by watch-* and subscribe-* commands, fires registered update handlers.
 void obelisk_client::monitor(uint32_t timeout_milliseconds)
 {
     auto deadline = steady_clock::now() + milliseconds(timeout_milliseconds);
 
     zmq::poller poller;
+    poller.add(subscribe_router_);
+    poller.add(subscribe_socket_);
     poller.add(block_socket_);
     poller.add(transaction_socket_);
 
@@ -251,13 +290,25 @@ void obelisk_client::monitor(uint32_t timeout_milliseconds)
             on_transaction_update_(transaction);
         }
 
-    } while (steady_clock::now() < deadline);
+        // Forward incoming client subscribe router requests to the server.
+        if (identifiers.contains(subscribe_router_.id()))
+            forward_message(subscribe_router_, subscribe_socket_);
+
+        // Process server responses for subscribe calls.
+        if (identifiers.contains(subscribe_socket_.id()))
+            process_response(subscribe_socket_);
+
+    } while (!poller.terminated() && subscribe_requests_outstanding() &&
+        steady_clock::now() < deadline);
+
+    clear_outstanding_subscribe_requests((steady_clock::now() >= deadline) ?
+        error::channel_timeout : error::operation_failed);
 }
 
 // Create a message and send it to the internal router for forwarding
 // to the server.
 bool obelisk_client::send_request(const std::string& command,
-    uint32_t id, const data_chunk& payload)
+    uint32_t id, const data_chunk& payload, bool subscription)
 {
     zmq::message message;
     // First, add the required delimiter since we're sending to our
@@ -267,7 +318,9 @@ bool obelisk_client::send_request(const std::string& command,
     message.enqueue(to_chunk(to_little_endian(id)));
     message.enqueue(payload);
 
-    return dealer_.send(message) == error::success;
+    return subscription ?
+        subscribe_dealer_.send(message) == error::success :
+        dealer_.send(message) == error::success;
 }
 
 // Handlers.
@@ -562,13 +615,21 @@ void obelisk_client::attach_handlers()
         history_handlers_.erase(handler);
     };
 
+    // This handler locks subscription_handlers_ while running to avoid
+    // subscription handler state from changing while running (called from
+    // process_response).
     auto notification_handler = [this](const std::string&, uint32_t id,
         const data_chunk& payload)
     {
-        auto handler = update_handlers_.find(id);
-        if (handler == update_handlers_.end())
+        // Critical Section.
+        ///////////////////////////////////////////////////////////////////////////
+        boost::lock_guard<system::shared_mutex> lock(subscription_lock_);
+
+        auto it = subscription_handlers_.find(id);
+        if (it == subscription_handlers_.end())
             return;
 
+        auto& handler = it->second.first;
         // [ code:4 ]     <- if this is nonzero then rest may be empty.
         // [ sequence:2 ] <- if out of order there was a lost message.
         // [ height:4 ]   <- 0 for unconfirmed or error tx (cannot notify genesis).
@@ -579,8 +640,8 @@ void obelisk_client::attach_handlers()
         const auto ec = source.read_error_code();
         if (ec)
         {
-            handler->second(ec, 0, 0, {});
-            update_handlers_.erase(handler);
+            handler(ec, 0, 0, {});
+            subscription_handlers_.erase(it);
             return;
         }
 
@@ -590,14 +651,41 @@ void obelisk_client::attach_handlers()
 
         if (!source.is_exhausted())
         {
-            handler->second(error::bad_stream, 0, 0, {});
-            update_handlers_.erase(handler);
+            handler(error::bad_stream, 0, 0, {});
+            subscription_handlers_.erase(it);
             return;
         }
 
         // Caller must differentiate type of update if subscribed to multiple.
-        handler->second(ec, sequence, height, tx_hash);
-        update_handlers_.erase(handler);
+        handler(ec, sequence, height, tx_hash);
+
+        ///////////////////////////////////////////////////////////////////////////
+    };
+
+    // This handler locks subscription_handlers_ while running to avoid
+    // (un)subscription handler state from changing while running (called from
+    // process_response).
+    auto unsubscribe_handler = [this](const std::string&, uint32_t id,
+        const data_chunk& payload)
+    {
+        // Critical Section.
+        ///////////////////////////////////////////////////////////////////////////
+        boost::lock_guard<system::shared_mutex> lock(subscription_lock_);
+
+        auto it = unsubscription_handlers_.find(id);
+        if (it == unsubscription_handlers_.end())
+            return;
+
+        auto& handler = it->second.first;
+        const auto subscription = it->second.second;
+
+        data_source istream(payload);
+        istream_reader source(istream);
+        handler(source.read_error_code());
+        unsubscription_handlers_.erase(it);
+
+        // Terminate any listener monitoring this subscription.
+        terminate_unsubscriber(subscription);
     };
 
     auto hash_list_handler = [this](const std::string&, uint32_t id,
@@ -642,8 +730,10 @@ void obelisk_client::attach_handlers()
     REGISTER_HANDLER("blockchain.fetch_block_transaction_hashes", hash_list_handler);
     REGISTER_HANDLER("blockchain.fetch_stealth_transaction_hashes",
         hash_list_handler);
-    REGISTER_HANDLER("notification.address", notification_handler);
-    REGISTER_HANDLER("notification.stealth", notification_handler);
+    REGISTER_HANDLER("subscribe.address", notification_handler);
+    REGISTER_HANDLER("subscribe.stealth", notification_handler);
+    REGISTER_HANDLER("unsubscribe.address", unsubscribe_handler);
+    REGISTER_HANDLER("unsubscribe.stealth", unsubscribe_handler);
     REGISTER_HANDLER("server.version", version_handler);
 
 #undef REGISTER_HANDLER
@@ -667,7 +757,7 @@ void obelisk_client::handle_immediate(const std::string& command, uint32_t id,
 bool obelisk_client::requests_outstanding()
 {
     // We have requests outstanding if any of the handler maps are not
-    // empty.
+    // empty, except update/notification handlers.
     return
         !result_handlers_.empty() ||
         !height_handlers_.empty() ||
@@ -678,8 +768,18 @@ bool obelisk_client::requests_outstanding()
         !hash_list_handlers_.empty() ||
         !history_handlers_.empty() ||
         !stealth_handlers_.empty() ||
-        !update_handlers_.empty() ||
         !version_handlers_.empty();
+}
+
+// We have subscribe requests outstanding if the subscription handler map is not
+// empty.
+bool obelisk_client::subscribe_requests_outstanding()
+{
+    // Critical Section.
+    ///////////////////////////////////////////////////////////////////////////
+    boost::lock_guard<system::shared_mutex> lock(subscription_lock_);
+    return !subscription_handlers_.empty() || !unsubscription_handlers_.empty();
+    ///////////////////////////////////////////////////////////////////////////
 }
 
 void obelisk_client::clear_outstanding_requests(const code& ec)
@@ -687,7 +787,6 @@ void obelisk_client::clear_outstanding_requests(const code& ec)
 #define INVOKE_HANDLER_0 handler.second(ec)
 #define INVOKE_HANDLER_1 handler.second(ec, {})
 #define INVOKE_HANDLER_2 handler.second(ec, {}, {})
-#define INVOKE_HANDLER_3 handler.second(ec, {}, {}, {})
 
 #define CLEAR_OUTSTANDING(handlers, ec, handler_version) \
     for (auto& handler: handlers) \
@@ -705,14 +804,28 @@ void obelisk_client::clear_outstanding_requests(const code& ec)
     CLEAR_OUTSTANDING(hash_list_handlers_, ec, 1);
     CLEAR_OUTSTANDING(history_handlers_, ec, 1);
     CLEAR_OUTSTANDING(stealth_handlers_, ec, 1);
-    CLEAR_OUTSTANDING(update_handlers_, ec, 3);
     CLEAR_OUTSTANDING(version_handlers_, ec, 1);
 
 #undef CLEAR_OUTSTANDING
 #undef INVOKE_HANDLER_0
 #undef INVOKE_HANDLER_1
 #undef INVOKE_HANDLER_2
-#undef INVOKE_HANDLER_3
+}
+
+void obelisk_client::clear_outstanding_subscribe_requests(const code& ec)
+{
+    // Critical Section.
+    ///////////////////////////////////////////////////////////////////////////
+    boost::lock_guard<system::shared_mutex> lock(subscription_lock_);
+
+    for (auto& it: subscription_handlers_)
+        it.second.first(ec, {}, {}, {});
+    for (auto& it: unsubscription_handlers_)
+        it.second.first(ec);
+
+    subscription_handlers_.clear();
+    unsubscription_handlers_.clear();
+    ///////////////////////////////////////////////////////////////////////////
 }
 
 // Fetchers.
@@ -1028,30 +1141,44 @@ void obelisk_client::blockchain_fetch_stealth_transaction_hashes(
 // Subscribers.
 //-----------------------------------------------------------------------------
 
-void obelisk_client::subscribe_address(update_handler handler,
-    const wallet::payment_address& address)
+uint32_t obelisk_client::subscribe_address(update_handler handler,
+    const payment_address& address)
 {
     return subscribe_address(handler, address.hash());
 }
 
 // address.subscribe is obsolete, but can pass through to address.subscribe2.
 // This is a simplified overload for a non-private payment address subscription.
-void obelisk_client::subscribe_address(update_handler handler,
+uint32_t obelisk_client::subscribe_address(update_handler handler,
     const short_hash& address_hash)
 {
     static const std::string command = "subscribe.address";
     // [ address_hash:20 ]
     const auto data = build_chunk({ address_hash });
+
+    // Critical Section.
+    ///////////////////////////////////////////////////////////////////////////
+    subscription_lock_.lock();
     const auto id = ++last_request_index_;
-    update_handlers_[id] = handler;
-    if (!send_request(command, id, data))
+    subscription_handlers_[id] = { handler, data };
+    subscription_lock_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (!send_request(command, id, data, true))
+    {
         handle_immediate(command, id, error::network_unreachable);
-    else
-        handler(error::success, {}, {}, {});
+        return null_subscription;
+    }
+
+    // NOTE: legacy behaviour is to call the hander with success to indicate
+    // subscription success.  Since we can now return null_subscription, we
+    // could skip this call here.
+    handler(error::success, {}, {}, {});
+    return id;
 }
 
 // This overload supports a prefix for either stealth or payment address.
-void obelisk_client::subscribe_stealth(update_handler handler,
+uint32_t obelisk_client::subscribe_stealth(update_handler handler,
     const binary& stealth_prefix)
 {
     static const std::string command = "subscribe.stealth";
@@ -1061,7 +1188,7 @@ void obelisk_client::subscribe_stealth(update_handler handler,
         bits > stealth_address::max_filter_bits)
     {
         handler(error::operation_failed, {}, {}, {});
-        return;
+        return null_subscription;
     }
 
     // [ prefix_bitsize:1 ]
@@ -1072,14 +1199,99 @@ void obelisk_client::subscribe_stealth(update_handler handler,
         stealth_prefix.blocks()
     });
 
+    // Critical Section.
+    ///////////////////////////////////////////////////////////////////////////
+    subscription_lock_.lock();
     const auto id = ++last_request_index_;
-    update_handlers_[id] = handler;
+    subscription_handlers_[id] = { handler, data };
+    subscription_lock_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
 
-    if (!send_request(command, id, data))
+    if (!send_request(command, id, data, true))
+    {
         handle_immediate(command, id, error::network_unreachable);
-    else
-        handler(error::success, {}, {}, {});
+        return null_subscription;
+    }
+
+    // NOTE: legacy behaviour is to call the hander with success to indicate
+    // subscription success.  Since we can now return null_subscription, we
+    // could skip this call here.
+    handler(error::success, {}, {}, {});
+    return id;
 }
+
+bool obelisk_client::unsubscribe_address(result_handler handler,
+    uint32_t subscription)
+{
+    static const std::string command = "unsubscribe.address";
+
+    data_chunk data;
+
+    // Critical Section.
+    ///////////////////////////////////////////////////////////////////////////
+    subscription_lock_.lock();
+    auto it = subscription_handlers_.find(subscription);
+    if (it == subscription_handlers_.end())
+        return false;
+
+    const auto id = ++last_request_index_;
+    unsubscription_handlers_[id] = { handler, subscription };
+
+    data = it->second.second;
+    subscription_lock_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (!send_request(command, id, data, true))
+    {
+        handle_immediate(command, id, error::network_unreachable);
+        return false;
+    }
+
+    return true;
+}
+
+bool obelisk_client::unsubscribe_stealth(result_handler handler,
+    uint32_t subscription)
+{
+    static const std::string command = "unsubscribe.stealth";
+
+    data_chunk data;
+
+    // Critical Section.
+    ///////////////////////////////////////////////////////////////////////////
+    subscription_lock_.lock();
+    auto it = subscription_handlers_.find(subscription);
+    if (it == subscription_handlers_.end())
+        return false;
+
+    const auto id = ++last_request_index_;
+    unsubscription_handlers_[id] = { handler, subscription };
+
+    data = it->second.second;
+    subscription_lock_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (!send_request(command, id, data, true))
+    {
+        handle_immediate(command, id, error::network_unreachable);
+        return false;
+    }
+
+    return true;
+}
+
+// Must be called with subscription_lock_ locked (called from
+// unsubscription_handler).
+bool obelisk_client::terminate_unsubscriber(uint32_t subscription)
+{
+    auto it = subscription_handlers_.find(subscription);
+    if (it == subscription_handlers_.end())
+        return false;
+
+    subscription_handlers_.erase(it);
+    return true;
+}
+
 
 } // namespace client
 } // namespace libbitcoin

--- a/test/obelisk_client.cpp
+++ b/test/obelisk_client.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(client__unsubscribe_address__test_ok)
         BOOST_REQUIRE(id != obelisk_client::null_subscription);
         BOOST_REQUIRE(client.unsubscribe_address(on_done, id) == true);
 
-        poller.wait(500);
+        poller.wait(2000);
         BOOST_REQUIRE(unsubscribe_complete == true);
     };
 


### PR DESCRIPTION
Logically split up client queries that wait for completion using wait() and subscriptions that wait for completion using monitor().

This implementation has separate routing and handling for all of the various subscription types, which is an alternative to tracking additional state on query handling to determine what is being waited on vs monitored.

Add a subscribe_address API call that directly takes a payment address (in addition to keeping the existing one that takes an address hash).

Add unsubscribe_address and unsubscribe_stealth to allow server to free up state and to cancel existing local monitoring state.  Resolves https://github.com/libbitcoin/libbitcoin-server/issues/377